### PR TITLE
retry/subsequent classification changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "frontend-asset-classification",
       "version": "0.1.0",
       "dependencies": {
-        "@provenanceio/walletconnect-js": "^1.0.10",
+        "@provenanceio/wallet-lib": "^2.4.3",
+        "@provenanceio/walletconnect-js": "^1.2.11",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
@@ -1746,9 +1747,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -2797,9 +2798,9 @@
       }
     },
     "node_modules/@provenanceio/wallet-lib": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@provenanceio/wallet-lib/-/wallet-lib-1.1.1.tgz",
-      "integrity": "sha512-R8FHPz0rz4v+S0BenfqxtbcxLUOdmoblWmu9shhBIFY4zwQPQaMITQ9L9iIQCsIZyt6WRDKqD4dvY8NLII2rlg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@provenanceio/wallet-lib/-/wallet-lib-2.4.3.tgz",
+      "integrity": "sha512-6glgTY06Rx+0EanN2XfqD4NabFcmy+V1iLc8G/eN5a8x1Qf5OFyY7eZ26ukfh8tBk3wk7jTffhXEiMzfoA4vLg==",
       "dependencies": {
         "@tendermint/belt": "0.3.0",
         "@tendermint/sig": "0.6.0",
@@ -2825,6 +2826,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/bigjs"
       }
+    },
+    "node_modules/@provenanceio/wallet-lib/node_modules/grpc-web": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.2.1.tgz",
+      "integrity": "sha512-ibBaJPzfMVuLPgaST9w0kZl60s+SnkPBQp6QKdpEr85tpc1gXW2QDqSne9xiyiym0logDfdUSm4aX5h9YBA2mw=="
     },
     "node_modules/@provenanceio/wallet-lib/node_modules/typedoc": {
       "version": "0.21.4",
@@ -2863,21 +2869,40 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/@provenanceio/walletconnect-js": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@provenanceio/walletconnect-js/-/walletconnect-js-1.0.10.tgz",
-      "integrity": "sha512-zqCOU6D1xJMB22hqMQVrPPAHd6ZCVQWWoEuYTCTHzZg6k93EOOpo318xXV+ZDwFtCv8RvDVr6c/yxLlLCEF97Q==",
+    "node_modules/@provenanceio/wallet-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@provenanceio/wallet-utils/-/wallet-utils-1.0.1.tgz",
+      "integrity": "sha512-tesSD5en/L15Oz30mkKjbbEXjWLVnfvBg4GRlrAPh2y7Yek8hepMRzhiGCdYOUEGNXNWVoKkbsrY2Dcc6lsZ2Q==",
       "dependencies": {
-        "@provenanceio/wallet-lib": "1.1.1",
+        "@tendermint/belt": "^0.3.0"
+      }
+    },
+    "node_modules/@provenanceio/walletconnect-js": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@provenanceio/walletconnect-js/-/walletconnect-js-1.2.11.tgz",
+      "integrity": "sha512-GMGVWjRt40qs41joaDMdlF0XNATGezJqF3kzBNYOHgAA29UAobaVPJ90YPcR9vPCkG6PgAmFgJLJk7lI5nGIcA==",
+      "dependencies": {
+        "@babel/runtime": "7.16.7",
+        "@provenanceio/wallet-utils": "1.0.1",
         "@walletconnect/client": "1.6.5",
         "@walletconnect/utils": "1.6.6",
         "base64url": "3.0.1",
         "bip32": "2.0.6",
         "google-protobuf": "3.16.0",
         "qrcode": "1.5.0",
-        "react": "17.0.2",
         "secp256k1": "4.0.2",
         "styled-components": "5.3.3"
+      }
+    },
+    "node_modules/@provenanceio/walletconnect-js/node_modules/@babel/runtime": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@provenanceio/walletconnect-js/node_modules/@emotion/is-prop-valid": {
@@ -4162,12 +4187,12 @@
       }
     },
     "node_modules/@walletconnect/browser-utils": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.8.tgz",
-      "integrity": "sha512-iCL0XCWOZaABIc0lqA79Vyaybr3z26nt8mxiwvfrG8oaKUf5Y21Of4dj+wIXQ4Hhblre6SgDlU0Ffb39+1THOw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz",
+      "integrity": "sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==",
       "dependencies": {
         "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/types": "^1.8.0",
         "@walletconnect/window-getters": "1.0.0",
         "@walletconnect/window-metadata": "1.0.0",
         "detect-browser": "5.2.0"
@@ -4185,24 +4210,24 @@
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.8.tgz",
-      "integrity": "sha512-9xcQ0YNf9JUFb0YOX1Mpy4Yojt+6w2yQz/0aIEyj2X/s9D71NW0fTYsMcdhkLOI7mn2cqVbx2t1lRvdgqsbrSQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-aFTHvEEbXcZ8XdWBw6rpQDte41Rxwnuk3SgTD8/iKGSRTni50gI9S3YEzMj05jozSiOBxQci4pJDMVhIUMtarw==",
       "dependencies": {
-        "@walletconnect/socket-transport": "^1.7.8",
-        "@walletconnect/types": "^1.7.8",
-        "@walletconnect/utils": "^1.7.8"
+        "@walletconnect/socket-transport": "^1.8.0",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       }
     },
     "node_modules/@walletconnect/core/node_modules/@walletconnect/utils": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
-      "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
+      "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.7.8",
+        "@walletconnect/browser-utils": "^1.8.0",
         "@walletconnect/encoding": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/jsonrpc-utils": "^1.0.3",
+        "@walletconnect/types": "^1.8.0",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"
@@ -4232,7 +4257,7 @@
     "node_modules/@walletconnect/core/node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
       "engines": {
         "node": ">=4"
       }
@@ -4264,24 +4289,24 @@
       "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
     },
     "node_modules/@walletconnect/iso-crypto": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.8.tgz",
-      "integrity": "sha512-Qo6qDcMG0Ac+9fpWE0h/oE55NHLk6eM2vlXpWlQDN/me7RZGrkvk+LXsAkQ3UiYPEiPfq4eswcyRWC9AcrAscg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.8.0.tgz",
+      "integrity": "sha512-pWy19KCyitpfXb70hA73r9FcvklS+FvO9QUIttp3c2mfW8frxgYeRXfxLRCIQTkaYueRKvdqPjbyhPLam508XQ==",
       "dependencies": {
         "@walletconnect/crypto": "^1.0.2",
-        "@walletconnect/types": "^1.7.8",
-        "@walletconnect/utils": "^1.7.8"
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       }
     },
     "node_modules/@walletconnect/iso-crypto/node_modules/@walletconnect/utils": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
-      "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
+      "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.7.8",
+        "@walletconnect/browser-utils": "^1.8.0",
         "@walletconnect/encoding": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/jsonrpc-utils": "^1.0.3",
+        "@walletconnect/types": "^1.8.0",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"
@@ -4311,26 +4336,26 @@
     "node_modules/@walletconnect/iso-crypto/node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@walletconnect/jsonrpc-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.0.tgz",
-      "integrity": "sha512-11QXNq5H1PKZk7bP8SxgmCw3HRaDuPOVE+wObqEvmhc7OWYUZqfuaaMb+OXGRSOHL3sbC+XHfdeCxFTMXSFyng==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.1.tgz",
+      "integrity": "sha512-+6coTtOuChCqM+AoYyi4Q83p9l/laI6NvuM2/AHaZFuf0gT0NjW7IX2+86qGyizn7Ptq4AYZmfxurAxTnhefuw==",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0"
       }
     },
     "node_modules/@walletconnect/jsonrpc-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.0.tgz",
-      "integrity": "sha512-qUHbKUK6sHeHn67qtHZoLoYk5hS6x1arTPjKDRkY93/6Fx+ZmNIpdm1owX3l6aYueyegJ7mz43FpvYHUqJ8xcw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.3.tgz",
+      "integrity": "sha512-3yb49bPk16MNLk6uIIHPSHQCpD6UAo1OMOx1rM8cW/MPEAYAzrSW5hkhG7NEUwX9SokRIgnZK3QuQkiyNzBMhQ==",
       "dependencies": {
         "@walletconnect/environment": "^1.0.0",
-        "@walletconnect/jsonrpc-types": "^1.0.0"
+        "@walletconnect/jsonrpc-types": "^1.0.1"
       }
     },
     "node_modules/@walletconnect/randombytes": {
@@ -4349,24 +4374,24 @@
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "node_modules/@walletconnect/socket-transport": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.8.tgz",
-      "integrity": "sha512-bqEjLxfSzG79v2OT7XVOZoyUkg6g3yng0fURrdLusWs42fYHWnrSrIZDejFn8N5PiZk5R2edrggkQ7w0VUUAfw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.8.0.tgz",
+      "integrity": "sha512-5DyIyWrzHXTcVp0Vd93zJ5XMW61iDM6bcWT4p8DTRfFsOtW46JquruMhxOLeCOieM4D73kcr3U7WtyR4JUsGuQ==",
       "dependencies": {
-        "@walletconnect/types": "^1.7.8",
-        "@walletconnect/utils": "^1.7.8",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0",
         "ws": "7.5.3"
       }
     },
     "node_modules/@walletconnect/socket-transport/node_modules/@walletconnect/utils": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
-      "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
+      "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.7.8",
+        "@walletconnect/browser-utils": "^1.8.0",
         "@walletconnect/encoding": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/jsonrpc-utils": "^1.0.3",
+        "@walletconnect/types": "^1.8.0",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"
@@ -4396,7 +4421,7 @@
     "node_modules/@walletconnect/socket-transport/node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
       "engines": {
         "node": ">=4"
       }
@@ -4422,9 +4447,9 @@
       }
     },
     "node_modules/@walletconnect/types": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.8.tgz",
-      "integrity": "sha512-0oSZhKIrtXRJVP1jQ0EDTRtotQY6kggGjDcmm/LLQBKnOZXdPeo0sPkV/7DjT5plT3O7Cjc6JvuXt9WOY0hlCA=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.8.0.tgz",
+      "integrity": "sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg=="
     },
     "node_modules/@walletconnect/utils": {
       "version": "1.6.6",
@@ -4464,7 +4489,7 @@
     "node_modules/@walletconnect/utils/node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
       "engines": {
         "node": ">=4"
       }
@@ -6504,7 +6529,7 @@
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6683,7 +6708,7 @@
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
@@ -7682,7 +7707,7 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -7718,7 +7743,7 @@
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -10099,7 +10124,7 @@
     "node_modules/gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -10122,7 +10147,7 @@
     "node_modules/gauge/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -10133,7 +10158,7 @@
     "node_modules/gauge/node_modules/string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -10146,7 +10171,7 @@
     "node_modules/gauge/node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -10354,11 +10379,6 @@
         "grpc_tools_node_protoc_plugin": "bin/protoc_plugin.js"
       }
     },
-    "node_modules/grpc-web": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.2.1.tgz",
-      "integrity": "sha512-ibBaJPzfMVuLPgaST9w0kZl60s+SnkPBQp6QKdpEr85tpc1gXW2QDqSne9xiyiym0logDfdUSm4aX5h9YBA2mw=="
-    },
     "node_modules/gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -10467,7 +10487,7 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "node_modules/has-value": {
       "version": "1.0.0",
@@ -13710,9 +13730,9 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -14537,9 +14557,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -14841,7 +14861,7 @@
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15209,7 +15229,7 @@
     "node_modules/os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15217,7 +15237,7 @@
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17258,7 +17278,7 @@
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19800,9 +19820,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
+      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -20682,9 +20702,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.15.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
-      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
+      "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -22564,7 +22584,7 @@
     "node_modules/wif": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
       "dependencies": {
         "bs58check": "<3.0.0"
       }
@@ -22580,7 +22600,7 @@
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/workbox-background-sync": {
       "version": "5.1.4",
@@ -24126,9 +24146,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -24914,9 +24934,9 @@
       }
     },
     "@provenanceio/wallet-lib": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@provenanceio/wallet-lib/-/wallet-lib-1.1.1.tgz",
-      "integrity": "sha512-R8FHPz0rz4v+S0BenfqxtbcxLUOdmoblWmu9shhBIFY4zwQPQaMITQ9L9iIQCsIZyt6WRDKqD4dvY8NLII2rlg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@provenanceio/wallet-lib/-/wallet-lib-2.4.3.tgz",
+      "integrity": "sha512-6glgTY06Rx+0EanN2XfqD4NabFcmy+V1iLc8G/eN5a8x1Qf5OFyY7eZ26ukfh8tBk3wk7jTffhXEiMzfoA4vLg==",
       "requires": {
         "@tendermint/belt": "0.3.0",
         "@tendermint/sig": "0.6.0",
@@ -24935,6 +24955,11 @@
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.1.1.tgz",
           "integrity": "sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg=="
+        },
+        "grpc-web": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.2.1.tgz",
+          "integrity": "sha512-ibBaJPzfMVuLPgaST9w0kZl60s+SnkPBQp6QKdpEr85tpc1gXW2QDqSne9xiyiym0logDfdUSm4aX5h9YBA2mw=="
         },
         "typedoc": {
           "version": "0.21.4",
@@ -24959,23 +24984,39 @@
         }
       }
     },
-    "@provenanceio/walletconnect-js": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@provenanceio/walletconnect-js/-/walletconnect-js-1.0.10.tgz",
-      "integrity": "sha512-zqCOU6D1xJMB22hqMQVrPPAHd6ZCVQWWoEuYTCTHzZg6k93EOOpo318xXV+ZDwFtCv8RvDVr6c/yxLlLCEF97Q==",
+    "@provenanceio/wallet-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@provenanceio/wallet-utils/-/wallet-utils-1.0.1.tgz",
+      "integrity": "sha512-tesSD5en/L15Oz30mkKjbbEXjWLVnfvBg4GRlrAPh2y7Yek8hepMRzhiGCdYOUEGNXNWVoKkbsrY2Dcc6lsZ2Q==",
       "requires": {
-        "@provenanceio/wallet-lib": "1.1.1",
+        "@tendermint/belt": "^0.3.0"
+      }
+    },
+    "@provenanceio/walletconnect-js": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@provenanceio/walletconnect-js/-/walletconnect-js-1.2.11.tgz",
+      "integrity": "sha512-GMGVWjRt40qs41joaDMdlF0XNATGezJqF3kzBNYOHgAA29UAobaVPJ90YPcR9vPCkG6PgAmFgJLJk7lI5nGIcA==",
+      "requires": {
+        "@babel/runtime": "7.16.7",
+        "@provenanceio/wallet-utils": "1.0.1",
         "@walletconnect/client": "1.6.5",
         "@walletconnect/utils": "1.6.6",
         "base64url": "3.0.1",
         "bip32": "2.0.6",
         "google-protobuf": "3.16.0",
         "qrcode": "1.5.0",
-        "react": "17.0.2",
         "secp256k1": "4.0.2",
         "styled-components": "5.3.3"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "@emotion/is-prop-valid": {
           "version": "0.8.8",
           "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -25927,12 +25968,12 @@
       }
     },
     "@walletconnect/browser-utils": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.8.tgz",
-      "integrity": "sha512-iCL0XCWOZaABIc0lqA79Vyaybr3z26nt8mxiwvfrG8oaKUf5Y21Of4dj+wIXQ4Hhblre6SgDlU0Ffb39+1THOw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz",
+      "integrity": "sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==",
       "requires": {
         "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/types": "^1.8.0",
         "@walletconnect/window-getters": "1.0.0",
         "@walletconnect/window-metadata": "1.0.0",
         "detect-browser": "5.2.0"
@@ -25950,24 +25991,24 @@
       }
     },
     "@walletconnect/core": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.8.tgz",
-      "integrity": "sha512-9xcQ0YNf9JUFb0YOX1Mpy4Yojt+6w2yQz/0aIEyj2X/s9D71NW0fTYsMcdhkLOI7mn2cqVbx2t1lRvdgqsbrSQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-aFTHvEEbXcZ8XdWBw6rpQDte41Rxwnuk3SgTD8/iKGSRTni50gI9S3YEzMj05jozSiOBxQci4pJDMVhIUMtarw==",
       "requires": {
-        "@walletconnect/socket-transport": "^1.7.8",
-        "@walletconnect/types": "^1.7.8",
-        "@walletconnect/utils": "^1.7.8"
+        "@walletconnect/socket-transport": "^1.8.0",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       },
       "dependencies": {
         "@walletconnect/utils": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
-          "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
+          "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
           "requires": {
-            "@walletconnect/browser-utils": "^1.7.8",
+            "@walletconnect/browser-utils": "^1.8.0",
             "@walletconnect/encoding": "^1.0.1",
-            "@walletconnect/jsonrpc-utils": "^1.0.0",
-            "@walletconnect/types": "^1.7.8",
+            "@walletconnect/jsonrpc-utils": "^1.0.3",
+            "@walletconnect/types": "^1.8.0",
             "bn.js": "4.11.8",
             "js-sha3": "0.8.0",
             "query-string": "6.13.5"
@@ -25991,7 +26032,7 @@
         "strict-uri-encode": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+          "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
         }
       }
     },
@@ -26022,24 +26063,24 @@
       "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
     },
     "@walletconnect/iso-crypto": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.8.tgz",
-      "integrity": "sha512-Qo6qDcMG0Ac+9fpWE0h/oE55NHLk6eM2vlXpWlQDN/me7RZGrkvk+LXsAkQ3UiYPEiPfq4eswcyRWC9AcrAscg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.8.0.tgz",
+      "integrity": "sha512-pWy19KCyitpfXb70hA73r9FcvklS+FvO9QUIttp3c2mfW8frxgYeRXfxLRCIQTkaYueRKvdqPjbyhPLam508XQ==",
       "requires": {
         "@walletconnect/crypto": "^1.0.2",
-        "@walletconnect/types": "^1.7.8",
-        "@walletconnect/utils": "^1.7.8"
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       },
       "dependencies": {
         "@walletconnect/utils": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
-          "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
+          "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
           "requires": {
-            "@walletconnect/browser-utils": "^1.7.8",
+            "@walletconnect/browser-utils": "^1.8.0",
             "@walletconnect/encoding": "^1.0.1",
-            "@walletconnect/jsonrpc-utils": "^1.0.0",
-            "@walletconnect/types": "^1.7.8",
+            "@walletconnect/jsonrpc-utils": "^1.0.3",
+            "@walletconnect/types": "^1.8.0",
             "bn.js": "4.11.8",
             "js-sha3": "0.8.0",
             "query-string": "6.13.5"
@@ -26063,25 +26104,25 @@
         "strict-uri-encode": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+          "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
         }
       }
     },
     "@walletconnect/jsonrpc-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.0.tgz",
-      "integrity": "sha512-11QXNq5H1PKZk7bP8SxgmCw3HRaDuPOVE+wObqEvmhc7OWYUZqfuaaMb+OXGRSOHL3sbC+XHfdeCxFTMXSFyng==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.1.tgz",
+      "integrity": "sha512-+6coTtOuChCqM+AoYyi4Q83p9l/laI6NvuM2/AHaZFuf0gT0NjW7IX2+86qGyizn7Ptq4AYZmfxurAxTnhefuw==",
       "requires": {
         "keyvaluestorage-interface": "^1.0.0"
       }
     },
     "@walletconnect/jsonrpc-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.0.tgz",
-      "integrity": "sha512-qUHbKUK6sHeHn67qtHZoLoYk5hS6x1arTPjKDRkY93/6Fx+ZmNIpdm1owX3l6aYueyegJ7mz43FpvYHUqJ8xcw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.3.tgz",
+      "integrity": "sha512-3yb49bPk16MNLk6uIIHPSHQCpD6UAo1OMOx1rM8cW/MPEAYAzrSW5hkhG7NEUwX9SokRIgnZK3QuQkiyNzBMhQ==",
       "requires": {
         "@walletconnect/environment": "^1.0.0",
-        "@walletconnect/jsonrpc-types": "^1.0.0"
+        "@walletconnect/jsonrpc-types": "^1.0.1"
       }
     },
     "@walletconnect/randombytes": {
@@ -26100,24 +26141,24 @@
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "@walletconnect/socket-transport": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.8.tgz",
-      "integrity": "sha512-bqEjLxfSzG79v2OT7XVOZoyUkg6g3yng0fURrdLusWs42fYHWnrSrIZDejFn8N5PiZk5R2edrggkQ7w0VUUAfw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.8.0.tgz",
+      "integrity": "sha512-5DyIyWrzHXTcVp0Vd93zJ5XMW61iDM6bcWT4p8DTRfFsOtW46JquruMhxOLeCOieM4D73kcr3U7WtyR4JUsGuQ==",
       "requires": {
-        "@walletconnect/types": "^1.7.8",
-        "@walletconnect/utils": "^1.7.8",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0",
         "ws": "7.5.3"
       },
       "dependencies": {
         "@walletconnect/utils": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
-          "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
+          "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
           "requires": {
-            "@walletconnect/browser-utils": "^1.7.8",
+            "@walletconnect/browser-utils": "^1.8.0",
             "@walletconnect/encoding": "^1.0.1",
-            "@walletconnect/jsonrpc-utils": "^1.0.0",
-            "@walletconnect/types": "^1.7.8",
+            "@walletconnect/jsonrpc-utils": "^1.0.3",
+            "@walletconnect/types": "^1.8.0",
             "bn.js": "4.11.8",
             "js-sha3": "0.8.0",
             "query-string": "6.13.5"
@@ -26141,7 +26182,7 @@
         "strict-uri-encode": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+          "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
         },
         "ws": {
           "version": "7.5.3",
@@ -26152,9 +26193,9 @@
       }
     },
     "@walletconnect/types": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.8.tgz",
-      "integrity": "sha512-0oSZhKIrtXRJVP1jQ0EDTRtotQY6kggGjDcmm/LLQBKnOZXdPeo0sPkV/7DjT5plT3O7Cjc6JvuXt9WOY0hlCA=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.8.0.tgz",
+      "integrity": "sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg=="
     },
     "@walletconnect/utils": {
       "version": "1.6.6",
@@ -26188,7 +26229,7 @@
         "strict-uri-encode": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+          "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
         }
       }
     },
@@ -27827,7 +27868,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -27981,7 +28022,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -28754,7 +28795,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -28783,7 +28824,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -30582,7 +30623,7 @@
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -30602,7 +30643,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -30610,7 +30651,7 @@
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -30620,7 +30661,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -30770,11 +30811,6 @@
         "node-pre-gyp": "^0.15.0"
       }
     },
-    "grpc-web": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.2.1.tgz",
-      "integrity": "sha512-ibBaJPzfMVuLPgaST9w0kZl60s+SnkPBQp6QKdpEr85tpc1gXW2QDqSne9xiyiym0logDfdUSm4aX5h9YBA2mw=="
-    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -30848,7 +30884,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -33241,9 +33277,9 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
     },
     "jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -33909,9 +33945,9 @@
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -34166,7 +34202,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -34435,12 +34471,12 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ=="
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "osenv": {
       "version": "0.1.5",
@@ -36070,7 +36106,7 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
         }
       }
     },
@@ -38075,9 +38111,9 @@
       }
     },
     "styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
+      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -38750,9 +38786,9 @@
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
     },
     "uglify-js": {
-      "version": "3.15.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
-      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
+      "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
       "optional": true
     },
     "unbox-primitive": {
@@ -40249,7 +40285,7 @@
     "wif": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
       "requires": {
         "bs58check": "<3.0.0"
       }
@@ -40262,7 +40298,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "workbox-background-sync": {
       "version": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "homepage": "http://provenance-io.github.io/frontend-asset-classification",
   "dependencies": {
-    "@provenanceio/walletconnect-js": "^1.0.10",
+    "@provenanceio/wallet-lib": "^2.4.3",
+    "@provenanceio/walletconnect-js": "^1.2.11",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/AssetClassification/EntityDetailDisplay.tsx
+++ b/src/components/AssetClassification/EntityDetailDisplay.tsx
@@ -1,38 +1,23 @@
-import { FunctionComponent, useEffect, useState } from "react";
-import { EntityDetail } from "../../models"
+import { FunctionComponent } from "react";
+import { EntityDetail, newEntityDetail } from "../../models"
+import { deepReplace } from "../../utils";
 import { InputOrDisplay } from "../Input";
 
 interface EntityDetailProps {
-    detail: EntityDetail,
+    detail?: EntityDetail,
     editable: boolean,
-    handleChange: () => any,
+    detailChanged: (detail: EntityDetail) => any,
 }
 
-const initialState = (entityDetail?: EntityDetail) => ({
-    name: entityDetail?.name || '',
-    description: entityDetail?.description || '',
-    home_url: entityDetail?.home_url || '',
-    source_url: entityDetail?.source_url || '',
-})
-
-export const EntityDetailDisplay: FunctionComponent<EntityDetailProps> = ({ detail, editable, handleChange }) => {
-    const [params, setParams] = useState(initialState(detail));
-
-    useEffect(() => setParams(initialState(detail)), [detail]);
-
-    const updateParam = (key: string, value: string) => {
-        setParams({
-            ...params,
-            [key]: value,
-        });
-        (detail as any)[key] = value;
-        handleChange();
+export const EntityDetailDisplay: FunctionComponent<EntityDetailProps> = ({ detail, editable, detailChanged }) => {
+    const handleChange = (key: string, value: string) => {
+        detailChanged(deepReplace(detail || newEntityDetail(), key, value))
     };
 
     return <>
-        <InputOrDisplay label="Name" value={params.name} editable={editable} onChange={(e) => { updateParam('name', e.target.value) }} />
-        <InputOrDisplay label="Description" value={params.description} editable={editable} onChange={(e) => { updateParam('description', e.target.value) }} />
-        <InputOrDisplay label="Home URL" type="url" value={params.home_url} editable={editable} onChange={(e) => { updateParam('home_url', e.target.value) }} />
-        <InputOrDisplay label="Source URL" type="url" value={params.source_url} editable={editable} onChange={(e) => { updateParam('source_url', e.target.value) }} />
+        <InputOrDisplay label="Name" value={detail?.name || ''} editable={editable} onChange={(e) => { handleChange('name', e.target.value) }} />
+        <InputOrDisplay label="Description" value={detail?.description || ''} editable={editable} onChange={(e) => { handleChange('description', e.target.value) }} />
+        <InputOrDisplay label="Home URL" type="url" value={detail?.home_url || ''} editable={editable} onChange={(e) => { handleChange('home_url', e.target.value) }} />
+        <InputOrDisplay label="Source URL" type="url" value={detail?.source_url || ''} editable={editable} onChange={(e) => { handleChange('source_url', e.target.value) }} />
     </>;
 }

--- a/src/components/AssetClassification/FeeDestination.tsx
+++ b/src/components/AssetClassification/FeeDestination.tsx
@@ -1,6 +1,8 @@
+import deepcopy from "deepcopy";
 import { FunctionComponent, useEffect, useState } from "react";
 import styled from "styled-components";
-import { EntityDetail, FeeDestination, newEntityDetail } from "../../models";
+import { FeeDestination, newEntityDetail } from "../../models";
+import { deepReplace } from "../../utils";
 import { RemoveButton } from "../Button";
 import { InputOrDisplay } from "../Input";
 import { EntityDetailDisplay } from "./EntityDetailDisplay";
@@ -28,38 +30,30 @@ const FeeDestinationContentWrapper = styled.div`
 interface FeeDestinationDetailsProps {
     destination: FeeDestination,
     editable: boolean,
-    handleChange: () => any,
+    destinationChanged: (destination: FeeDestination) => any,
     requestRemoval: () => any,
 }
 
-export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps> = ({ destination, editable, handleChange, requestRemoval }) => {
+export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps> = ({ destination, editable, destinationChanged, requestRemoval }) => {
+    const [updatedDestination, setUpdatedDestination] = useState(destination);
+
     useEffect(() => {
         if (!destination.entity_detail) {
             destination.entity_detail = newEntityDetail();
         }
+        setUpdatedDestination(deepcopy(destination))
     }, [destination])
 
-    const [params, setParams] = useState({
-        address: destination.address,
-        fee_amount: destination.fee_amount,
-        entity_detail: destination.entity_detail,
-    })
-
-    const updateParam = (key: string, value: any) => {
-        setParams({
-            ...params,
-            [key]: value
-        });
-        (destination as any)[key] = value
-        handleChange()
+    const updateDestination = (key: string, value: any) => {
+        destinationChanged(deepReplace(updatedDestination, key, value))
     }
 
     return <FeeDestinationControlWrapper>
         {editable && <div><RemoveButton onClick={requestRemoval} /></div>}
         <FeeDestinationContentWrapper>
-            <InputOrDisplay label="Address" value={destination.address} editable={editable} onChange={(e) => { updateParam('address', e.target.value) }} />
-            <InputOrDisplay label="Fee Amount" value={destination.fee_amount} editable={editable} onChange={(e) => { updateParam('fee_amount', e.target.value) }} />
-            <EntityDetailDisplay detail={destination.entity_detail as EntityDetail} editable={editable} handleChange={handleChange} />
+            <InputOrDisplay label="Address" value={updatedDestination.address} editable={editable} onChange={(e) => { updateDestination('address', e.target.value) }} />
+            <InputOrDisplay label="Fee Amount" value={updatedDestination.fee_amount} editable={editable} onChange={(e) => { updateDestination('fee_amount', e.target.value) }} />
+            <EntityDetailDisplay detail={updatedDestination.entity_detail} editable={editable} detailChanged={detail => updateDestination('entity_detail', detail)} />
         </FeeDestinationContentWrapper>
     </FeeDestinationControlWrapper>;
 }

--- a/src/components/AssetClassification/Verifier.tsx
+++ b/src/components/AssetClassification/Verifier.tsx
@@ -3,7 +3,7 @@ import deepcopy from "deepcopy"
 import { FunctionComponent, useState, useEffect } from "react"
 import styled from "styled-components"
 import { DARK_TEXT } from "../../constants"
-import { VerifierDetail, newEntityDetail, OnboardingCost, newOnboardingCost, newFeeDestination, newSubsequentClassificationDetail } from "../../models"
+import { VerifierDetail, newEntityDetail, OnboardingCost, newOnboardingCost, newFeeDestination } from "../../models"
 import { AssetClassificationContractService } from "../../services"
 import { ActionContainer, AddButton, Button, IconButtonBody, RemoveButton } from "../Button"
 import { H5, H6 } from "../Headers"
@@ -105,34 +105,6 @@ export const AssetVerifier: FunctionComponent<AssetVerifierProps> = ({ asset_typ
         updateVerifierField('fee_destinations', [...updatedVerifier.fee_destinations, newFeeDestination()])
     }
 
-    const addRetryCost = () => {
-        updateVerifierField('retry_cost', newOnboardingCost())
-    }
-
-    const removeRetryCost = () => {
-        updateVerifierField('retry_cost', undefined)
-    }
-
-    const addRetryCostFeeDestination = () => {
-        updateVerifierField('retry_cost.fee_destinations', [...(updatedVerifier.retry_cost?.fee_destinations || []), newFeeDestination()])
-    }
-
-    const addSubsequentClassificationDetail = () => {
-        updateVerifierField('subsequent_classification_detail', newSubsequentClassificationDetail())
-    }
-
-    const removeSubsequentClassificationDetail = () => {
-        updateVerifierField('subsequent_classification_detail', undefined)
-    }
-
-    const addSubsequentClassificationCost = () => {
-        updateVerifierField('subsequent_classification_detail.cost', newOnboardingCost())
-    }
-
-    const removeSubsequentClassificationCost = () => {
-        updateVerifierField('subsequent_classification_detail.cost', undefined)
-    }
-
     return <AssetVerifierWrapper>
         {!creating && editable && <DeleteVerifierButton onClick={requestRemoval} title="Remove Asset Verifier" />}
         <AssetVerifierDetails>
@@ -173,7 +145,7 @@ export const AssetVerifier: FunctionComponent<AssetVerifierProps> = ({ asset_typ
                         editable={editable}
                         onChange={(e) => { updateVerifierField(`subsequent_classification_detail.applicable_asset_types.${i}`, e.target.value)}} 
                     />
-                    <RemoveButton onClick={() => updateVerifierField('subsequent_classification_detail.applicable_asset_types', arrayOrUndefined(updatedVerifier.subsequent_classification_detail?.applicable_asset_types?.filter((_, j) => i !== j)))} style={{ alignSelf: 'flex-end' }} title={`Remove Applicable Asset Type`} />
+                    {editable && <RemoveButton onClick={() => updateVerifierField('subsequent_classification_detail.applicable_asset_types', arrayOrUndefined(updatedVerifier.subsequent_classification_detail?.applicable_asset_types?.filter((_, j) => i !== j)))} style={{ alignSelf: 'flex-end' }} title={`Remove Applicable Asset Type`} />}
                 </HeaderContainer>)}
                 
             </OnboardingCostManager>
@@ -204,7 +176,7 @@ const OnboardingCostManager: FunctionComponent<OnboardingCostManagerProps> = ({ 
         {onboardingCost && <>
             <HeaderContainer>
                 <InputOrDisplay label="Cost" value={onboardingCost?.cost || ''} editable={editable} onChange={(e) => { updateCost('cost', e.target.value) }} />
-                <AddButton onClick={() => updateCost('fee_destinations', [...onboardingCost.fee_destinations, newFeeDestination()])} style={{ alignSelf: 'flex-end' }} title={`Add ${title} Fee Destination`} />
+                {editable && <AddButton onClick={() => updateCost('fee_destinations', [...onboardingCost.fee_destinations, newFeeDestination()])} style={{ alignSelf: 'flex-end' }} title={`Add ${title} Fee Destination`} />}
             </HeaderContainer>
             {children}
             <H5>Fee Destinations</H5>

--- a/src/components/AssetClassification/Verifier.tsx
+++ b/src/components/AssetClassification/Verifier.tsx
@@ -3,15 +3,16 @@ import deepcopy from "deepcopy"
 import { FunctionComponent, useState, useEffect } from "react"
 import styled from "styled-components"
 import { DARK_TEXT } from "../../constants"
-import { VerifierDetail, newEntityDetail, EntityDetail, FeeDestination } from "../../models"
+import { VerifierDetail, newEntityDetail, OnboardingCost, newOnboardingCost, newFeeDestination, newSubsequentClassificationDetail } from "../../models"
 import { AssetClassificationContractService } from "../../services"
-import { ActionContainer, AddButton, Button, RemoveButton } from "../Button"
-import { H5 } from "../Headers"
-import { InputOrDisplay } from "../Input"
+import { ActionContainer, AddButton, Button, IconButtonBody, RemoveButton } from "../Button"
+import { H5, H6 } from "../Headers"
+import { InputOrDisplay, InputOrDisplayWrapper } from "../Input"
 import { FeeDestinationDetails } from "./FeeDestination"
 import deepEqual from "deep-equal";
 import { useTransaction } from "../../hooks"
 import { EntityDetailDisplay } from "./EntityDetailDisplay"
+import { arrayOrUndefined, deepReplace } from "../../utils"
 
 const AssetVerifierWrapper = styled.div`
     position: relative;
@@ -52,89 +53,179 @@ interface AssetVerifierProps {
 
 const getOnboardingCost = (verifier: VerifierDetail): string => `${verifier.onboarding_cost}${verifier.onboarding_denom}`
 
-const intitialState = (verifier: VerifierDetail) => ({
-    address: verifier.address,
-    onboardingCost: getOnboardingCost(verifier),
-    fee_destinations: verifier.fee_destinations
-})
-
-
 export const AssetVerifier: FunctionComponent<AssetVerifierProps> = ({ asset_type, verifier, editable, creating = false, newDefinition, definitionDirty, service, onChange = (v) => {}, requestRemoval = () => {} }) => {
     // todo: edit handler at this level for individual asset verifier update
 
     const { walletConnectState } = useWalletConnect()
     const [, setTransaction] = useTransaction()
 
-    const [originalVerifier, setOriginalVerifier] = useState(verifier)
+    const [updatedVerifier, setUpdatedVerifier] = useState(verifier)
     const [dirty, setDirty] = useState(false)
     const [onboardingCost, setOnboardingCost] = useState(getOnboardingCost(verifier))
 
-    const [params, setParams] = useState(intitialState(verifier))
-
-    const handleChange = () => {
-        setDirty(!deepEqual(verifier, originalVerifier, { strict: true }))
-        onChange(verifier)
+    const handleChange = (newVerifier: VerifierDetail) => {
+        setUpdatedVerifier(newVerifier)
+        setDirty(!deepEqual(verifier, newVerifier, { strict: true }))
     }
 
-    const updateParam = (key: string, value: any) => {
-        setParams({
-            ...params,
-            [key]: value
-        });
-        (verifier as any)[key] = value
-        handleChange()
+    const updateVerifierField = (key: string, value: any) => {
+        handleChange(deepReplace(updatedVerifier, key, value))
     }
 
     useEffect(() => {
-        setOriginalVerifier(deepcopy(verifier))
-        setParams(intitialState(verifier))
-        setOnboardingCost(getOnboardingCost(verifier))
         if (!verifier.entity_detail) {
             verifier.entity_detail = newEntityDetail()
         }
+        setUpdatedVerifier(deepcopy(verifier))
+        setOnboardingCost(getOnboardingCost(verifier))
     }, [verifier])
 
     const handleCostChange = (cost: string) => {
         const match = /(?<cost>[0-9]*)(?<denom>[a-zA-Z]*)/.exec(cost)
-        verifier.onboarding_cost = (match?.groups && match.groups['cost']) || '0'
-        verifier.onboarding_denom = (match?.groups && match.groups['denom']) || ''
-        setOnboardingCost(getOnboardingCost(verifier))
-        handleChange()
+        const newVerifier: VerifierDetail = {
+            ...updatedVerifier,
+            onboarding_cost: (match?.groups && match.groups['cost']) || '0',
+            onboarding_denom: (match?.groups && match.groups['denom']) || ''
+        }
+        handleChange(newVerifier)
+        setOnboardingCost(getOnboardingCost(newVerifier))
     }
 
     const handleUpdate = async() => {
-        const message = await service.getUpdateAssetVerifierMessage(asset_type, verifier, walletConnectState.address)
+        const message = await service.getUpdateAssetVerifierMessage(asset_type, updatedVerifier, walletConnectState.address)
         setTransaction(message)
     }
 
     const handleCreate = async() => {
-        const message = await service.getAddAssetVerifierMessage(asset_type, verifier, walletConnectState.address)
+        const message = await service.getAddAssetVerifierMessage(asset_type, updatedVerifier, walletConnectState.address)
         setTransaction(message)
     }
 
     const addFeeDestination = () => {
-        const newFeeDestination: FeeDestination = {
-            address: '',
-            fee_amount: '',
-        }
-        updateParam('fee_destinations', [...params.fee_destinations, newFeeDestination])
+        updateVerifierField('fee_destinations', [...updatedVerifier.fee_destinations, newFeeDestination()])
+    }
+
+    const addRetryCost = () => {
+        updateVerifierField('retry_cost', newOnboardingCost())
+    }
+
+    const removeRetryCost = () => {
+        updateVerifierField('retry_cost', undefined)
+    }
+
+    const addRetryCostFeeDestination = () => {
+        updateVerifierField('retry_cost.fee_destinations', [...(updatedVerifier.retry_cost?.fee_destinations || []), newFeeDestination()])
+    }
+
+    const addSubsequentClassificationDetail = () => {
+        updateVerifierField('subsequent_classification_detail', newSubsequentClassificationDetail())
+    }
+
+    const removeSubsequentClassificationDetail = () => {
+        updateVerifierField('subsequent_classification_detail', undefined)
+    }
+
+    const addSubsequentClassificationCost = () => {
+        updateVerifierField('subsequent_classification_detail.cost', newOnboardingCost())
+    }
+
+    const removeSubsequentClassificationCost = () => {
+        updateVerifierField('subsequent_classification_detail.cost', undefined)
     }
 
     return <AssetVerifierWrapper>
         {!creating && editable && <DeleteVerifierButton onClick={requestRemoval} title="Remove Asset Verifier" />}
         <AssetVerifierDetails>
-            <InputOrDisplay label="Verifier Address" value={params.address} editable={editable} onChange={(e) => { updateParam('address', e.target.value) }} />
+            <InputOrDisplay label="Verifier Address" value={updatedVerifier.address} editable={editable} onChange={(e) => { updateVerifierField('address', e.target.value) }} />
             <InputOrDisplay label="Onboarding Cost" value={onboardingCost} editable={editable} onChange={(e) => handleCostChange(e.target.value)} />
-            <EntityDetailDisplay detail={verifier.entity_detail as EntityDetail} editable={editable} handleChange={handleChange} />
+            <EntityDetailDisplay detail={updatedVerifier.entity_detail} editable={editable} detailChanged={(detail) => updateVerifierField('entity_detail', detail)} />
         </AssetVerifierDetails>
         <FeeDestinations>
-            <H5>Fee Destinations {editable && <AddButton onClick={addFeeDestination} style={{float: "right"}} title="Add Fee Destination" />}</H5>
-            {verifier.fee_destinations.length === 0 ? 'No Fee Destinations' : verifier.fee_destinations.map(destination => <FeeDestinationDetails key={destination.address} destination={destination} editable={editable} handleChange={handleChange} requestRemoval={() => updateParam('fee_destinations', params.fee_destinations.filter(d => d !== destination))} />)}
+            <HeaderContainer>
+                <H5>Fee Destinations</H5>
+                {editable && <AddButton onClick={addFeeDestination} title="Add Fee Destination" />}
+            </HeaderContainer>
+            {updatedVerifier.fee_destinations.length === 0 ? 'No Fee Destinations' : updatedVerifier.fee_destinations.map((destination, i) => <FeeDestinationDetails key={destination.address} destination={destination} editable={editable} destinationChanged={destination => updateVerifierField(`fee_destinations.${i}`, destination)} requestRemoval={() => updateVerifierField('fee_destinations', updatedVerifier.fee_destinations.filter((_, j) => i !== j))} />)}
+        </FeeDestinations>
+        <FeeDestinations>
+            <OnboardingCostManager
+                onboardingCost={updatedVerifier.retry_cost}
+                editable={editable}
+                title="Retry Cost"
+                updateOnboardingCost={cost => updateVerifierField('retry_cost', cost)} />
+        </FeeDestinations>
+        <FeeDestinations>
+            <OnboardingCostManager
+                onboardingCost={updatedVerifier.subsequent_classification_detail?.cost}
+                editable={editable}
+                title="Subsequent Classification Detail Cost"
+                updateOnboardingCost={cost => updateVerifierField('subsequent_classification_detail.cost', cost)}
+            >
+                <HeaderContainer>
+                    <H6>Applicable Asset Types</H6>
+                    {editable && <AddButton title="Add Applicable Asset Type" onClick={() => updateVerifierField('subsequent_classification_detail.applicable_asset_types', [...(updatedVerifier.subsequent_classification_detail?.applicable_asset_types || []), ''])} />}
+                </HeaderContainer>
+                {updatedVerifier.subsequent_classification_detail?.applicable_asset_types?.map((assetType, i) => <HeaderContainer key={`applicable-asset-type-${i}`}>
+                    <InputOrDisplay
+                        label=""
+                        style={{marginTop: '10px'}}
+                        value={assetType}
+                        editable={editable}
+                        onChange={(e) => { updateVerifierField(`subsequent_classification_detail.applicable_asset_types.${i}`, e.target.value)}} 
+                    />
+                    <RemoveButton onClick={() => updateVerifierField('subsequent_classification_detail.applicable_asset_types', arrayOrUndefined(updatedVerifier.subsequent_classification_detail?.applicable_asset_types?.filter((_, j) => i !== j)))} style={{ alignSelf: 'flex-end' }} title={`Remove Applicable Asset Type`} />
+                </HeaderContainer>)}
+                
+            </OnboardingCostManager>
         </FeeDestinations>
         {!newDefinition && !creating && editable && dirty && !definitionDirty && <ActionContainer><Button onClick={handleUpdate}>Update Verifier</Button></ActionContainer>}
         {!newDefinition && creating && <ActionContainer><Button onClick={handleCreate}>Add Verifier</Button></ActionContainer>}
     </AssetVerifierWrapper>
 }
 
+interface OnboardingCostManagerProps {
+    onboardingCost?: OnboardingCost,
+    updateOnboardingCost: (onboardingCost: OnboardingCost | undefined) => any,
+    editable: boolean,
+    title: string,
+}
+
+const OnboardingCostManager: FunctionComponent<OnboardingCostManagerProps> = ({ onboardingCost, updateOnboardingCost, editable, title, children }) => {
+    const updateCost = (path: string, value: any) => {
+        updateOnboardingCost(deepReplace(onboardingCost, path, value))
+    }
+
+    return <FeeDestinations>
+        <HeaderContainer>
+            <H5>{title}</H5>
+            {editable && !onboardingCost && <AddButton onClick={() => updateOnboardingCost(newOnboardingCost())} title={`Add ${title}`}/>}
+            {editable && onboardingCost && <RemoveButton onClick={() => updateOnboardingCost(undefined)} title={`Remove ${title}`}/>}
+        </HeaderContainer>
+        {onboardingCost && <>
+            <HeaderContainer>
+                <InputOrDisplay label="Cost" value={onboardingCost?.cost || ''} editable={editable} onChange={(e) => { updateCost('cost', e.target.value) }} />
+                <AddButton onClick={() => updateCost('fee_destinations', [...onboardingCost.fee_destinations, newFeeDestination()])} style={{ alignSelf: 'flex-end' }} title={`Add ${title} Fee Destination`} />
+            </HeaderContainer>
+            {children}
+            <H5>Fee Destinations</H5>
+            {!onboardingCost?.fee_destinations?.length ? 'No Fee Destinations' : onboardingCost.fee_destinations.map((destination, i) => <FeeDestinationDetails key={destination.address} destination={destination} editable={editable} destinationChanged={(d) => updateCost(`fee_destinations.${i}`, d)} requestRemoval={() => updateCost('fee_destinations', onboardingCost.fee_destinations.filter((_, j) => i !== j))} />)}
+        </>}
+    </FeeDestinations>
+}
+
 const FeeDestinations = styled.div`
+`
+
+const HeaderContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    > ${InputOrDisplayWrapper} {
+        flex-grow: 1;
+    }
+
+    > ${IconButtonBody} {
+        margin-left: 10px;
+    }
 `

--- a/src/components/Headers/index.tsx
+++ b/src/components/Headers/index.tsx
@@ -5,3 +5,4 @@ export const H2 = styled.h2``
 export const H3 = styled.h3``
 export const H4 = styled.h4``
 export const H5 = styled.h5``
+export const H6 = styled.h6``

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -37,6 +37,7 @@ export const LoginManager: FunctionComponent<LoginManagerProps> = () => {
             walletConnectService={wcs}
             walletConnectState={walletConnectState}
             title="Scan to initiate walletConnect-js session"
+            devWallets={["figure_web", "provenance_extension"]}
           />
     </>
 }

--- a/src/components/TransactionHandler/TransactionHandler.tsx
+++ b/src/components/TransactionHandler/TransactionHandler.tsx
@@ -40,20 +40,16 @@ export const TransactionHandler: FunctionComponent<TransactionHandlerProps> = ()
 
     useEffect(() => {
         const completeListener = (res: BroadcastResults) => {
-            console.log('CUSTOM_ACTION_COMPLETE', res)
             setTransaction()
             invalidateAssetDefinitions()
         }
         wcs.addListener(WINDOW_MESSAGES.CUSTOM_ACTION_COMPLETE, completeListener)
-        const failedListener = (res: BaseResults) => {
-            console.log('CUSTOM_ACTION_FAILED', res)
+        const failedListener = (res: BroadcastResults) => {
             setTransaction()
-            setError(`Transaction Error: ${res.error}`)
+            setError(`Transaction Error: ${(res as BaseResults).error}`)
         }
         wcs.addListener(WINDOW_MESSAGES.CUSTOM_ACTION_FAILED, failedListener)
-        console.log('listeners registered')
         return () => {
-            console.log('removing listeners')
             wcs.removeListener(WINDOW_MESSAGES.CUSTOM_ACTION_COMPLETE, completeListener)
             wcs.removeListener(WINDOW_MESSAGES.CUSTOM_ACTION_FAILED, failedListener)
         }

--- a/src/models/AssetClassificationContract.ts
+++ b/src/models/AssetClassificationContract.ts
@@ -49,11 +49,27 @@ export function newDefinition(): QueryAssetDefinitionResponse {
 }
 
 export interface VerifierDetail {
+    /// The Provenance Blockchain bech32 address of the verifier account.
     address: string,
+    /// The total amount charged to use the onboarding process this this verifier.
     onboarding_cost: string,
+    /// The coin denomination used for this onboarding process.
     onboarding_denom: string,
+    /// Each account that should receive fees when onboarding a new scope to the contract.
+    /// All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties
+    /// should sum to an amount less than or equal to the [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost).
+    /// Amounts not precisely equal in sum will cause this verifier detail to be considered invalid
+    /// and rejected in requests that include it.
     fee_destinations: FeeDestination[],
+    /// An optional set of fields that define the verifier, including its name and home URL location.
     entity_detail?: EntityDetail,
+    /// Defines the cost to use in place of the root onboarding_cost and fee_destinations when
+    /// retrying classification for a failed verification.  If not present, the original values
+    /// used for the first verification will be used.
+    retry_cost?: OnboardingCost,
+    /// An optional set of fields that define behaviors when classification is being run for an
+    /// asset that is already classified as a different type.
+    subsequent_classification_detail?: SubsequentClassificationDetail,
 }
 
 export function newVerifier(): VerifierDetail {
@@ -79,6 +95,44 @@ export interface FeeDestination {
     address: string,
     fee_amount: string,
     entity_detail?: EntityDetail,
+}
+
+export function newFeeDestination(): FeeDestination {
+    return {
+        address: '',
+        fee_amount: ''
+    }
+}
+
+export interface OnboardingCost {
+    /// The amount of coin to be paid when an asset is sent to the onboard_asset execute function.
+    cost: string,
+    /// Any specific fee destinations that should be sent to sources other than the selected verifier.
+    fee_destinations: FeeDestination[],
+}
+
+export function newOnboardingCost(): OnboardingCost {
+    return {
+        cost: '',
+        fee_destinations: [],
+    }
+}
+
+export interface SubsequentClassificationDetail {
+    /// The onboarding cost to use when classifying an asset using the associated verifier after
+    /// having already classified it as a different type with the same verifier.  If not set, the
+    /// default verifier costs are used.
+    cost?: OnboardingCost,
+    /// Specifies the asset types that an asset can be to have the subsequent classification cost
+    /// apply to them.  If an asset has been classified as any of the types in this list, the cost
+    /// will be used.  If the list is supplied as a None variant, any subsequent classifications will
+    /// use the cost.  This value will be rejected if it is supplied as an empty vector.
+    applicable_asset_types?: string[],
+}
+
+export function newSubsequentClassificationDetail(): SubsequentClassificationDetail {
+    return {
+    }
 }
 
 export interface EntityDetail {

--- a/src/services/WasmService.ts
+++ b/src/services/WasmService.ts
@@ -1,4 +1,3 @@
-import { Error as ServerError } from 'grpc-web';
 import { QueryClient as WasmQueryClient } from "@provenanceio/wallet-lib/lib/proto/cosmwasm/wasm/v1/query_grpc_web_pb";
 import { QuerySmartContractStateRequest } from "@provenanceio/wallet-lib/lib/proto/cosmwasm/wasm/v1/query_pb";
 import { QueryClient as NameQueryClient } from "@provenanceio/wallet-lib/lib/proto/provenance/name/v1/query_grpc_web_pb";
@@ -16,7 +15,7 @@ export class WasmService {
 
     lookupContractByName(name: string): Promise<string> {
         return new Promise((resolve, reject) => {
-            this.nameQueryClient.resolve(new QueryResolveRequest().setName(name), null, (error: ServerError, res) => {
+            this.nameQueryClient.resolve(new QueryResolveRequest().setName(name), null, (error, res) => {
                 if (error) {
                     reject(new Error(`wasmService.lookupContractByName error: Code: ${error.code} Message: ${error.message}`))
                 } else {
@@ -32,7 +31,7 @@ export class WasmService {
             this.wasmQueryClient.smartContractState(new QuerySmartContractStateRequest()
                 .setAddress(contractAddress)
                 .setQueryData(queryData)
-                , null, (error: ServerError, res) => {
+                , null, (error, res) => {
                 if (error) {
                     reject(new Error(`wasmService.queryWasmCustom error: Code: ${error.code} Message: ${error.message}`))
                 } else {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,33 @@
+export function deepReplace(item: any, key: string | string[], value: any): any {
+    if (typeof key === 'string') {
+        key = key.split('.')
+    }
+
+    if (key.length === 0) {
+        throw Error('Unexpected deep replacement on index of 0 length')
+    }
+
+    if (key.length === 1) {
+        return conditionalReplace(item, key[0], value)
+    }
+
+    return conditionalReplace(item, key[0], deepReplace(item[key[0]], key.slice(1), value))
+}
+
+function conditionalReplace(item: any, key: string, value: any): any {
+    if (item instanceof Array) {
+        const indexToReplace = +key
+        return item.map((curr, i) => i === indexToReplace ? value : curr)
+    }
+    return {
+        ...item,
+        [key]: value
+    }
+}
+
+export function arrayOrUndefined<T>(arr?: Array<T>): Array<T> | undefined {
+    if (arr && arr.length > 0) {
+        return arr
+    }
+    return undefined
+}


### PR DESCRIPTION
There are so many fields now I should probably figure out a way to make the UI a bit prettier, but it seems that all the functionality is at least working, so that's good

* Upgraded to newer walletconnect-js (not latest, as there are some changes that I need to research, mainly the 'network' option doesn't seem to exist any longer [I think it is tied to the wallet itself now], need to figure out how that works with this UI and the testnet/mainnet routing deal)
* Re-jiggered the state management to not be mutating objects and trying to keep things in-sync. Further changes needed to make the 'dirty' calculation more accurate (sometimes it is popping up indicating updates, but that is due to differences in undefined/empty strings in fields)... I think I would like to take this a step further and switch to something like Formik to make all this more straightforward
* The meat/potatoes of being able to manage retry cost/subsequent classification detail w/ applicable asset types and fee destinations